### PR TITLE
Ensure the teamUrl has a value before trying to substring it

### DIFF
--- a/Mattermost/Utils.swift
+++ b/Mattermost/Utils.swift
@@ -44,11 +44,11 @@ class Utils {
     class func getShouldForceUpdate() -> Bool {
         let now = NSDate().timeIntervalSince1970
         let time = defaults.doubleForKey(CURRENT_BACKGROUND_TIME)
-        
+
         if (time == 0) {
             return true
         }
-                
+
         if (now - time < 300) {
             return false
         }
@@ -58,14 +58,16 @@ class Utils {
     
     class func setTeamUrl(var teamUrl: String) {
         
-        if (teamUrl[teamUrl.endIndex.advancedBy(-1)] == "/") {
-            teamUrl = teamUrl.substringToIndex(teamUrl.endIndex.advancedBy(-1))
-        }
-        
-        let index = teamUrl.rangeOfString("/", options: .BackwardsSearch)?.startIndex
-        if (index != nil) {
-            setProp(CURRENT_URL, value: teamUrl.substringToIndex(index!))
-            setProp(CURRENT_TEAM_NAME, value: teamUrl.substringFromIndex(index!.advancedBy(1)))
+        if (!teamUrl.isEmpty) {
+            if (teamUrl[teamUrl.endIndex.advancedBy(-1)] == "/") {
+                teamUrl = teamUrl.substringToIndex(teamUrl.endIndex.advancedBy(-1))
+            }
+            
+            let index = teamUrl.rangeOfString("/", options: .BackwardsSearch)?.startIndex
+            if (index != nil) {
+                setProp(CURRENT_URL, value: teamUrl.substringToIndex(index!))
+                setProp(CURRENT_TEAM_NAME, value: teamUrl.substringFromIndex(index!.advancedBy(1)))
+            }
         }
     }
     


### PR DESCRIPTION
When starting the iOS app, if you just click on the 'Next' button without filling in anything for the Team URL value, you will get an error rather than UI feedback that the URL is invalid.

By checking that teamUrl is not empty before trying to substring it, we ensure that the app doesn't crash, and we get valid UI feedback.
