### PR TITLE
PLT-4519 Fix detection of file download urls

### DIFF
--- a/Mattermost/HomeViewController.swift
+++ b/Mattermost/HomeViewController.swift
@@ -17,7 +17,7 @@ class MyURLProtocol: NSURLProtocol {
         let nav = app.window!.rootViewController as! UINavigationController
         if let currentView = nav.visibleViewController as? HomeViewController {
             
-            let isGetFile  = request.URL?.path?.containsString("/files/get/") ?? false
+            let isGetFile = request.URL?.path?.containsString("/files/") ?? false
             if (isServer && isGetFile) {
                 return false
             }
@@ -302,8 +302,8 @@ class HomeViewController: UIViewController, UIWebViewDelegate, MattermostApiProt
         }
         
         // Open files in another browser
-        let isFile  = request.URL?.path?.containsString("/files/get/") ?? false
-        if (currentUrl.containsString((request.URL?.host)!) && isFile) {
+        let isGetFile = request.URL?.path?.containsString("/files/") ?? false
+        if (currentUrl.containsString((request.URL?.host)!) && isGetFile) {
             self.navigationController?.navigationBarHidden = false
             return true
         }


### PR DESCRIPTION
#### Summary

When clicking the download link on a file in the iOS app, the file is opened inside of the webview. We used to display a navbar with a back button so the user can return to the app. When the path for the file download endpoint was changed (`/files/get` became `/files/:fileId/get`), our check for a file "get" url broke.
The navbar was no longer being displayed, so the user had no way to exit the file view (other than force quitting the app). Also if the file was an image it was being displayed at a much higher zoom level than it should've been. This fixes both side effects of the regression.

This bug (and the fix for it) really only apply to images & pdfs. Video & audio files can't be opened/played from the iOS app anyway (AFIK). That's a separate bug.
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4519
#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
