### PR TITLE
PLT-4517 Ignore webview error for video/audio files

### DIFF
--- a/Mattermost/HomeViewController.swift
+++ b/Mattermost/HomeViewController.swift
@@ -47,7 +47,7 @@ class MyURLProtocol: NSURLProtocol {
         }
 
         return false
-    } 
+    }
 }
 
 var homeView: HomeViewController?
@@ -233,8 +233,12 @@ class HomeViewController: UIViewController, UIWebViewDelegate, MattermostApiProt
     }
     
     func webView(webView: UIWebView, didFailLoadWithError error: NSError?) {
-        activityIndicator.stopAnimating()
         print("Home view fail with error \(error)");
+        activityIndicator.stopAnimating()
+        if (error?.code == 204 && error?.domain == "WebKitErrorDomain") {
+            // "Plug-in handled load" (i.e. audio/video file)
+            return
+        }
         
         if errorCount < 3 {
             sleep(3)


### PR DESCRIPTION
#### Summary

When clicking the download link on a file in the iOS app, the file is opened inside of the webview. For audio/video files, the user would see a brief flash of safari's media player (with a play button) and then the webview would immediately close and the user would be redirected back to the app. This happened because when the `UIWebView` loads a raw video/audio file, it delegates to the appropriate plugin handler, which actually triggers an error:

```
Error "Plug-in handled load"
Domain=WebKitErrorDomain
Code=204
UserInfo={
  NSErrorFailingURLStringKey=https://example.mattermost.com/api/v3/files/3346788aabbceffghiknoprrxy/get,
  NSErrorFailingURLKey=https://example.mattermost.com/api/v3/files/3346788aabbceffghiknoprrxy/get,
  WebKitErrorMIMETypeKey=video/mp4,
  NSLocalizedDescription=Plug-in handled load
}
```

Our webview error handler treated this as a true exception, and redirected back to the app and reloaded. Investigation led me to conclude that this error is a special case which needs to be ignored. With this fix the webview stays open and the file can be played. I was only to verify that it worked for audio files. It seems that the iOS simulator won't play video files, and I'm not able to run the app on device because I lack the signing creds/certs. This fix should be tested on device before the PR is merged.
#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-4517
#### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
