### PR TITLE
Set ‘Use Legacy Swift Language Version’ flag to YES

### DIFF
--- a/Mattermost.xcodeproj/project.pbxproj
+++ b/Mattermost.xcodeproj/project.pbxproj
@@ -385,12 +385,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				INFOPLIST_FILE = Mattermost/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattermost.Mattermost;
 				PRODUCT_NAME = Mattermost;
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -401,12 +403,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				INFOPLIST_FILE = Mattermost/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mattermost.Mattermost;
 				PRODUCT_NAME = Mattermost;
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -419,6 +423,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -427,6 +432,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mattermost.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Mattermost;
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mattermost.app/Mattermost";
 			};
 			name = Debug;
@@ -439,10 +445,12 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 				);
+				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				INFOPLIST_FILE = MattermostTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mattermost.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Mattermost;
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Mattermost.app/Mattermost";
 			};
 			name = Release;

--- a/Mattermost/HomeViewController.swift
+++ b/Mattermost/HomeViewController.swift
@@ -275,7 +275,7 @@ class HomeViewController: UIViewController, UIWebViewDelegate, MattermostApiProt
         }
         
         // Open mailto: another browser
-        let isMailTo = request.URL?.absoluteString.hasPrefix("mailto:") ?? false
+        let isMailTo = request.URL?.absoluteString?.hasPrefix("mailto:") ?? false
         if (isMailTo) {
             UIApplication.sharedApplication().openURL(request.URL!)
             return false


### PR DESCRIPTION
I opened the Swift Legacy flag and fixed a optional syntax error.
It can be build on Xcode 8.2 now with Swift 2.3 .