### PR TITLE
Don't crash on attaching photo

### DIFF
--- a/Mattermost/Info.plist
+++ b/Mattermost/Info.plist
@@ -46,6 +46,10 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Attach photo and video from camera</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>You can safely ignore and discard this</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>


### PR DESCRIPTION
Hey, look 😎
iOS 10 requires to have these keys if you try to use photo picker / photo capture API, so we had a crash.

You (and Mattermost team) are free to use the code which I submitted to this pull request. Consider it is licensed under [WTFPL](http://www.wtfpl.net/about/) which is compatible with yours.
I won't sign your agreement because I don't want to disclose my mailing address or phone number.

Looking forward to your react-native app.
Cheers